### PR TITLE
Route middleware test

### DIFF
--- a/tests/ComponentFinderTest.php
+++ b/tests/ComponentFinderTest.php
@@ -59,6 +59,12 @@ class ComponentFinderTest extends TestCase
     {
         $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Middlewares\DemoMiddleware::class));
     }
+    
+    /** @test */
+    public function it_finds_route_middlewares()
+    {
+        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Middlewares\RouteMiddleware::class));
+    }
 
     /** @test */
     public function it_finds_migrations()

--- a/tests/Stubs/HttpKernel.php
+++ b/tests/Stubs/HttpKernel.php
@@ -3,6 +3,7 @@
 namespace Wnx\LaravelStats\Tests\Stubs;
 
 use Wnx\LaravelStats\Tests\Stubs\Middlewares\DemoMiddleware;
+use Wnx\LaravelStats\Tests\Stubs\Middlewares\RouteMiddleware;
 
 class HttpKernel extends \Illuminate\Foundation\Http\Kernel
 {
@@ -64,5 +65,6 @@ class HttpKernel extends \Illuminate\Foundation\Http\Kernel
         'can'        => \Illuminate\Auth\Middleware\Authorize::class,
         'guest'      => Middleware\RedirectIfAuthenticated::class,
         'throttle'   => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'route'      => RouteMiddleware::class,
     ];
 }

--- a/tests/Stubs/Middlewares/RouteMiddleware.php
+++ b/tests/Stubs/Middlewares/RouteMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\Middlewares;
+
+use Closure;
+
+class RouteMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Include Route Middleware Test

- Add a new test middleware.
- Add a test to verify that the middleware is classified as a middleware.
- Add a test to verify that it is detected as part of the detection tests.